### PR TITLE
bug: Require collateral to be member of pool

### DIFF
--- a/contracts/Uniloan.sol
+++ b/contracts/Uniloan.sol
@@ -877,6 +877,8 @@ contract UniloanPair {
      * @param outMin the minimum amount of liquidity to borrow
      */
     function loan(address collateral, address borrow, uint amount, uint outMin) external returns (uint) {
+        require(collateral == token0 || collateral == token1, "Uniloan::loan: Collateral not member of pool");
+
         uint _before = IERC20(collateral).balanceOf(address(this));
         IERC20(collateral).transferFrom(msg.sender, address(this), amount);
         uint _after = IERC20(collateral).balanceOf(address(this));


### PR DESCRIPTION
Explicitly require that collateral provided is one of the two pool assets 